### PR TITLE
[PULL REQUEST] Change Scoring System To Depend on Percentage of Fans

### DIFF
--- a/src/features/admin/components/SessionSetupScreen.tsx
+++ b/src/features/admin/components/SessionSetupScreen.tsx
@@ -39,10 +39,8 @@ export function SessionSetupScreen() {
   // Question selection (ordered list)
   const [selectedQuestionIds, setSelectedQuestionIds] = useState<string[]>([]);
 
-  // Sponsor selection (one)
-  const [selectedSponsorId, setSelectedSponsorId] = useState<string | null>(
-    null,
-  );
+  // Sponsor selection (one or more)
+  const [selectedSponsorIds, setSelectedSponsorIds] = useState<string[]>([]);
   const [showNewSponsor, setShowNewSponsor] = useState(false);
   const [newSponsorName, setNewSponsorName] = useState('');
   const [newSponsorReward, setNewSponsorReward] = useState('');
@@ -96,6 +94,12 @@ export function SessionSetupScreen() {
   }
 
   // ── Sponsor helpers ──
+  function toggleSponsor(id: string) {
+    setSelectedSponsorIds((prev) =>
+      prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id],
+    );
+  }
+
   async function handleAddSponsor() {
     if (!newSponsorName.trim()) {
       setNewSponsorError('Sponsor name is required.');
@@ -108,7 +112,9 @@ export function SessionSetupScreen() {
         newSponsorName.trim(),
         newSponsorReward.trim(),
       );
-      setSelectedSponsorId(created.id);
+      setSelectedSponsorIds((prev) =>
+        prev.includes(created.id) ? prev : [...prev, created.id],
+      );
       setNewSponsorName('');
       setNewSponsorReward('');
       setShowNewSponsor(false);
@@ -123,7 +129,7 @@ export function SessionSetupScreen() {
   function validate(): string | null {
     if (selectedTeamIds.length !== 2) return 'Select exactly 2 teams.';
     if (selectedQuestionIds.length === 0) return 'Select at least 1 question.';
-    if (!selectedSponsorId) return 'Select a sponsor.';
+    if (selectedSponsorIds.length === 0) return 'Select at least 1 sponsor.';
     return null;
   }
 
@@ -139,7 +145,7 @@ export function SessionSetupScreen() {
       await createSession({
         teamIds: selectedTeamIds,
         questionOrder: selectedQuestionIds,
-        sponsorId: selectedSponsorId!,
+        sponsorIds: selectedSponsorIds,
         settings: { showTeamScores, allowLateJoin },
       });
       router.replace('/(admin)/dashboard');
@@ -164,7 +170,7 @@ export function SessionSetupScreen() {
         </Pressable>
         <Text style={styles.title}>New Session</Text>
         <Text style={styles.subtitle}>
-          Configure teams, questions, sponsor, and settings.
+          Configure teams, questions, sponsors, and settings.
         </Text>
       </View>
 
@@ -316,21 +322,24 @@ export function SessionSetupScreen() {
         )}
       </View>
 
-      {/* ── Section 3: Sponsor ── */}
+      {/* ── Section 3: Sponsors ── */}
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Select Sponsor</Text>
+        <Text style={styles.sectionTitle}>Select Sponsors</Text>
+        <Text style={styles.sectionHint}>
+          Winners can choose from these rewards at the end.
+        </Text>
 
         {sponsorsLoading ? (
           <ActivityIndicator color={AppColors.accent} style={styles.spinner} />
         ) : (
           sponsors.map((sponsor: Sponsor) => {
-            const selected = selectedSponsorId === sponsor.id;
+            const selected = selectedSponsorIds.includes(sponsor.id);
             return (
               <Pressable
                 key={sponsor.id}
-                onPress={() => setSelectedSponsorId(sponsor.id)}
+                onPress={() => toggleSponsor(sponsor.id)}
                 style={({ pressed }) => (pressed ? styles.pressed : undefined)}
-                accessibilityRole="radio"
+                accessibilityRole="checkbox"
                 accessibilityState={{ checked: selected }}
               >
                 <Card

--- a/src/features/admin/services/sessionService.ts
+++ b/src/features/admin/services/sessionService.ts
@@ -20,7 +20,7 @@ import { type GameSession, type Question } from '@/types';
 export interface CreateSessionInput {
   teamIds: string[];
   questionOrder: string[];
-  sponsorId: string;
+  sponsorIds: string[];
   settings: {
     showTeamScores: boolean;
     allowLateJoin: boolean;
@@ -34,7 +34,7 @@ export async function createSession(data: CreateSessionInput): Promise<string> {
       currentQuestionId: null,
       questionActive: false,
       questionStartTime: null,
-      sponsorId: data.sponsorId,
+      sponsorIds: data.sponsorIds,
       settings: data.settings,
       currentQuestion: null,
       correctOptionId: null,

--- a/src/features/admin/services/sessionService.ts
+++ b/src/features/admin/services/sessionService.ts
@@ -1,14 +1,18 @@
 import {
   addDoc,
+  arrayUnion,
   collection,
   doc,
   getDoc,
+  getDocs,
   increment,
   onSnapshot,
   orderBy,
   query,
   serverTimestamp,
   updateDoc,
+  where,
+  writeBatch,
   type Unsubscribe,
 } from 'firebase/firestore';
 
@@ -41,6 +45,7 @@ export async function createSession(data: CreateSessionInput): Promise<string> {
       teamIds: data.teamIds,
       questionOrder: data.questionOrder,
       currentQuestionIndex: -1,
+      scoredQuestionIds: [],
       createdAt: serverTimestamp(),
     }),
     resetSessionScores(data.teamIds),
@@ -103,19 +108,88 @@ export async function closeQuestion(
   sessionId: string,
   questionId: string,
 ): Promise<void> {
-  const questionSnap = await getDoc(doc(db, COLLECTIONS.QUESTIONS, questionId));
+  const sessionRef = doc(db, COLLECTIONS.GAME_SESSIONS, sessionId);
+  const questionRef = doc(db, COLLECTIONS.QUESTIONS, questionId);
+  const [sessionSnap, questionSnap] = await Promise.all([
+    getDoc(sessionRef),
+    getDoc(questionRef),
+  ]);
+  if (!sessionSnap.exists()) {
+    throw new Error(`Session ${sessionId} not found.`);
+  }
   if (!questionSnap.exists()) {
     throw new Error(`Question ${questionId} not found.`);
   }
-  const { correctOptionId } = questionSnap.data() as Pick<
-    Question,
-    'correctOptionId'
-  >;
+  const sessionData = sessionSnap.data() as Omit<GameSession, 'id'> & {
+    scoredQuestionIds?: string[];
+  };
+  const { correctOptionId } = questionSnap.data() as Pick<Question, 'correctOptionId'>;
+  const questionPoints = sessionData.currentQuestion?.points ?? 0;
 
-  await updateDoc(doc(db, COLLECTIONS.GAME_SESSIONS, sessionId), {
+  // Idempotency guard: if this question was already scored, do not increment
+  // team points a second time.
+  if (sessionData.scoredQuestionIds?.includes(questionId)) {
+    await updateDoc(sessionRef, {
+      questionActive: false,
+      correctOptionId,
+    });
+    return;
+  }
+
+  const submissionsQuery = query(
+    collection(db, COLLECTIONS.SUBMISSIONS),
+    where('sessionId', '==', sessionId),
+    where('questionId', '==', questionId),
+  );
+  const submissionsSnap = await getDocs(submissionsQuery);
+
+  const totalsByTeam = new Map<string, number>();
+  const correctByTeam = new Map<string, number>();
+  const batch = writeBatch(db);
+
+  submissionsSnap.docs.forEach((submissionDoc) => {
+    const data = submissionDoc.data() as {
+      teamId?: string;
+      selectedOptionId?: string;
+    };
+    const teamId = data.teamId;
+    const selectedOptionId = data.selectedOptionId;
+    if (!teamId || !selectedOptionId) return;
+
+    const isCorrect = selectedOptionId === correctOptionId;
+    const pointsEarned = isCorrect ? questionPoints : 0;
+    totalsByTeam.set(teamId, (totalsByTeam.get(teamId) ?? 0) + 1);
+    if (isCorrect) {
+      correctByTeam.set(teamId, (correctByTeam.get(teamId) ?? 0) + 1);
+    }
+
+    batch.update(submissionDoc.ref, {
+      isCorrect,
+      pointsEarned,
+    });
+  });
+
+  const sessionTeamIds = sessionData.teamIds ?? [];
+  sessionTeamIds.forEach((teamId) => {
+    const totalAnswers = totalsByTeam.get(teamId) ?? 0;
+    const correctAnswers = correctByTeam.get(teamId) ?? 0;
+    if (totalAnswers === 0) return;
+
+    const awardedPoints = Math.round((correctAnswers / totalAnswers) * questionPoints);
+    if (awardedPoints <= 0) return;
+
+    batch.update(doc(db, COLLECTIONS.TEAMS, teamId), {
+      currentSessionScore: increment(awardedPoints),
+    });
+  });
+
+  batch.update(sessionRef, {
     questionActive: false,
     correctOptionId,
+    scoredQuestionIds: arrayUnion(questionId),
   });
+
+  await batch.commit();
 }
 
 export async function endSession(sessionId: string): Promise<void> {

--- a/src/features/game/components/LobbyScreen.tsx
+++ b/src/features/game/components/LobbyScreen.tsx
@@ -67,16 +67,30 @@ export function LobbyScreen() {
   const router = useRouter();
   const { user } = useAuth();
   const { session, teams, isLoading } = useGameState();
-  const [sponsor, setSponsor] = useState<Sponsor | null>(null);
+  const [sponsors, setSponsors] = useState<Sponsor[]>([]);
 
   useEffect(() => {
-    if (!session?.sponsorId) return;
-    getDoc(doc(db, COLLECTIONS.SPONSORS, session.sponsorId)).then((snap) => {
-      if (snap.exists()) {
-        setSponsor({ id: snap.id, ...(snap.data() as Omit<Sponsor, 'id'>) });
-      }
+    const sponsorIds =
+      session?.sponsorIds && session.sponsorIds.length > 0
+        ? session.sponsorIds
+        : session?.sponsorId
+          ? [session.sponsorId]
+          : [];
+    if (sponsorIds.length === 0) {
+      setSponsors([]);
+      return;
+    }
+
+    Promise.all(
+      sponsorIds.map(async (sponsorId) => {
+        const snap = await getDoc(doc(db, COLLECTIONS.SPONSORS, sponsorId));
+        if (!snap.exists()) return null;
+        return { id: snap.id, ...(snap.data() as Omit<Sponsor, 'id'>) };
+      }),
+    ).then((loadedSponsors) => {
+      setSponsors(loadedSponsors.filter((s): s is Sponsor => s !== null));
     });
-  }, [session?.sponsorId]);
+  }, [session?.sponsorId, session?.sponsorIds]);
 
   const sortedTeams = [...teams].sort(
     (a, b) => b.currentSessionScore - a.currentSessionScore,
@@ -113,7 +127,9 @@ export function LobbyScreen() {
         />
       </View>
 
-      {sponsor ? <SponsorCard sponsor={sponsor} /> : null}
+      {sponsors.map((sponsor) => (
+        <SponsorCard key={sponsor.id} sponsor={sponsor} />
+      ))}
 
       {session.settings.showTeamScores && sortedTeams.length > 0 ? (
         <View style={styles.scoresSection}>

--- a/src/features/game/components/QuestionScreen.tsx
+++ b/src/features/game/components/QuestionScreen.tsx
@@ -103,7 +103,13 @@ export function QuestionScreen() {
   }, [isQuestionActive, submitted, router, sessionId]);
 
   async function handleSelectOption(optionId: string) {
-    if (submitted || isSubmitting || !user || !session?.currentQuestionId)
+    if (
+      submitted ||
+      isSubmitting ||
+      !user ||
+      !session?.currentQuestionId ||
+      !user.teamId
+    )
       return;
     setSelectedOptionId(optionId);
     setIsSubmitting(true);
@@ -114,7 +120,7 @@ export function QuestionScreen() {
         sessionId,
         session.currentQuestionId,
         user.uid,
-        user.teamId ?? '',
+        user.teamId,
         optionId,
       );
       setSubmitted(true);

--- a/src/features/game/components/ResultsScreen.tsx
+++ b/src/features/game/components/ResultsScreen.tsx
@@ -96,10 +96,17 @@ export function ResultsScreen() {
     (a, b) => b.currentSessionScore - a.currentSessionScore,
   );
   const winningTeam = sortedTeams[0] ?? null;
+  const sponsorCount =
+    session?.sponsorIds && session.sponsorIds.length > 0
+      ? session.sponsorIds.length
+      : session?.sponsorId
+        ? 1
+        : 0;
 
   const isOnWinningTeam =
     winningTeam !== null && user?.teamId === winningTeam.id;
-  const canClaimReward = isOnWinningTeam && user?.marketingOptIn === true;
+  const canClaimReward =
+    isOnWinningTeam && user?.marketingOptIn === true && sponsorCount > 0;
 
   function handleClaimReward() {
     router.push({
@@ -156,7 +163,8 @@ export function ResultsScreen() {
       {canClaimReward && (
         <View style={styles.rewardSection}>
           <Text style={styles.rewardHint}>
-            You qualified for a sponsor reward. Claim it below!
+            You qualified for a sponsor reward. Choose your reward and claim it
+            below!
           </Text>
           <Button
             label="Claim Your Reward"
@@ -175,9 +183,10 @@ export function ResultsScreen() {
         </Card>
       )}
 
-      {!session?.sponsorId ? null : (
+      {sponsorCount === 0 ? null : (
         <Text style={styles.sponsorLine}>
-          Powered by your sponsor · Session {sessionId}
+          Powered by {sponsorCount} sponsor{sponsorCount === 1 ? '' : 's'} ·
+          Session {sessionId}
         </Text>
       )}
 

--- a/src/features/game/components/TeamSelectionScreen.tsx
+++ b/src/features/game/components/TeamSelectionScreen.tsx
@@ -53,7 +53,7 @@ function TeamRow({
 export function TeamSelectionScreen() {
   const router = useRouter();
   const { sessionId } = useLocalSearchParams<{ sessionId: string }>();
-  const { user } = useAuth();
+  const { user, setUserTeam } = useAuth();
   const { teams, isLoading } = useTeams();
   const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
@@ -65,6 +65,7 @@ export function TeamSelectionScreen() {
     setError(null);
     try {
       await updateUserTeam(user.uid, selectedTeamId);
+      setUserTeam(selectedTeamId);
       router.replace({
         pathname: '/(fan)/[sessionId]/lobby',
         params: { sessionId },

--- a/src/features/game/components/WaitingScreen.tsx
+++ b/src/features/game/components/WaitingScreen.tsx
@@ -30,7 +30,6 @@ export function WaitingScreen() {
       !lockedQuestionIdRef.current ||
       scoreScoredRef.current ||
       !user?.uid ||
-      !user?.teamId ||
       !currentQuestion
     ) {
       return;
@@ -42,7 +41,7 @@ export function WaitingScreen() {
 
     const questionId = lockedQuestionIdRef.current;
     const submissionId = `${sessionId}_${questionId}_${user.uid}`;
-    const { uid, teamId } = user;
+    const { uid } = user;
     const { points } = currentQuestion;
     const revealedOptionId = correctOptionId;
 
@@ -54,17 +53,18 @@ export function WaitingScreen() {
         }
         const data = snap.data();
         const selected = data.selectedOptionId as string;
+        const submissionTeamId = data.teamId as string | undefined;
 
         setIsCorrect(selected === revealedOptionId);
 
-        if (data.isCorrect === null) {
+        if (data.isCorrect === null && submissionTeamId) {
           computeAndRecordScore(
             submissionId,
             selected,
             revealedOptionId,
             points,
             uid,
-            teamId!,
+            submissionTeamId,
           ).catch(() => {
             scoreScoredRef.current = false;
           });

--- a/src/features/game/components/WaitingScreen.tsx
+++ b/src/features/game/components/WaitingScreen.tsx
@@ -1,4 +1,4 @@
-import { doc, getDoc } from 'firebase/firestore';
+import { doc, onSnapshot } from 'firebase/firestore';
 import { useLocalSearchParams } from 'expo-router';
 import React, { useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
@@ -9,7 +9,6 @@ import { ScreenContainer } from '@/components/ui/ScreenContainer';
 import { COLLECTIONS } from '@/constants/firestore';
 import { AppColors, Spacing, Typography } from '@/constants/theme';
 import { useAuth } from '@/features/auth/hooks/useAuth';
-import { computeAndRecordScore } from '@/features/game/services/submissionService';
 import { useGameState } from '@/providers/GameStateProvider';
 import { type Team } from '@/types';
 
@@ -21,58 +20,30 @@ export function WaitingScreen() {
   const lockedQuestionIdRef = useRef<string | null>(
     session?.currentQuestionId ?? null,
   );
-  const scoreScoredRef = useRef(false);
   const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
 
   useEffect(() => {
     if (
       !correctOptionId ||
       !lockedQuestionIdRef.current ||
-      scoreScoredRef.current ||
       !user?.uid ||
       !currentQuestion
     ) {
       return;
     }
 
-    // Lock immediately (synchronously) so re-renders caused by dependency
-    // changes cannot start a second scoring pass while getDoc is in-flight.
-    scoreScoredRef.current = true;
-
     const questionId = lockedQuestionIdRef.current;
     const submissionId = `${sessionId}_${questionId}_${user.uid}`;
-    const { uid } = user;
-    const { points } = currentQuestion;
-    const revealedOptionId = correctOptionId;
+    const submissionRef = doc(db, COLLECTIONS.SUBMISSIONS, submissionId);
+    const unsubscribe = onSnapshot(submissionRef, (snap) => {
+      if (!snap.exists()) return;
+      const data = snap.data() as { isCorrect?: boolean | null };
+      if (typeof data.isCorrect === 'boolean') {
+        setIsCorrect(data.isCorrect);
+      }
+    });
 
-    getDoc(doc(db, COLLECTIONS.SUBMISSIONS, submissionId))
-      .then((snap) => {
-        if (!snap.exists()) {
-          scoreScoredRef.current = false;
-          return;
-        }
-        const data = snap.data();
-        const selected = data.selectedOptionId as string;
-        const submissionTeamId = data.teamId as string | undefined;
-
-        setIsCorrect(selected === revealedOptionId);
-
-        if (data.isCorrect === null && submissionTeamId) {
-          computeAndRecordScore(
-            submissionId,
-            selected,
-            revealedOptionId,
-            points,
-            uid,
-            submissionTeamId,
-          ).catch(() => {
-            scoreScoredRef.current = false;
-          });
-        }
-      })
-      .catch(() => {
-        scoreScoredRef.current = false;
-      });
+    return unsubscribe;
   }, [correctOptionId, user, sessionId, currentQuestion]);
 
   const sortedTeams: Team[] = [...teams].sort(

--- a/src/features/game/services/submissionService.ts
+++ b/src/features/game/services/submissionService.ts
@@ -1,7 +1,5 @@
 import {
   doc,
-  increment,
-  runTransaction,
   serverTimestamp,
   setDoc,
 } from 'firebase/firestore';
@@ -26,41 +24,5 @@ export async function submitAnswer(
     selectedOptionId,
     isCorrect: null,
     answeredAt: serverTimestamp(),
-  });
-}
-
-export async function computeAndRecordScore(
-  submissionId: string,
-  selectedOptionId: string,
-  correctOptionId: string,
-  points: number,
-  uid: string,
-  teamId: string,
-): Promise<void> {
-  await runTransaction(db, async (transaction) => {
-    const submissionRef = doc(db, COLLECTIONS.SUBMISSIONS, submissionId);
-    const submissionSnap = await transaction.get(submissionRef);
-
-    if (!submissionSnap.exists()) return;
-
-    // Idempotency guard: if a previous call already scored this submission,
-    // do not apply increments a second time.
-    if (submissionSnap.data().isCorrect !== null) return;
-
-    const isCorrect = selectedOptionId === correctOptionId;
-
-    transaction.update(submissionRef, {
-      isCorrect,
-      pointsEarned: isCorrect ? points : 0,
-    });
-
-    if (isCorrect) {
-      transaction.update(doc(db, COLLECTIONS.USERS, uid), {
-        totalPoints: increment(points),
-      });
-      transaction.update(doc(db, COLLECTIONS.TEAMS, teamId), {
-        currentSessionScore: increment(points),
-      });
-    }
   });
 }

--- a/src/features/rewards/components/RewardClaimScreen.tsx
+++ b/src/features/rewards/components/RewardClaimScreen.tsx
@@ -1,15 +1,19 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useState } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { doc, getDoc } from 'firebase/firestore';
+import React, { useEffect, useState } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { ScreenContainer } from '@/components/ui/ScreenContainer';
 import { TextField } from '@/components/ui/TextField';
 import { AppColors, Spacing, Typography } from '@/constants/theme';
+import { db } from '@/api/firebase';
+import { COLLECTIONS } from '@/constants/firestore';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import { useRewardClaim } from '@/features/rewards/hooks/useRewardClaim';
 import { useGameState } from '@/providers/GameStateProvider';
+import { type Sponsor } from '@/types';
 
 export function RewardClaimScreen() {
   const router = useRouter();
@@ -22,6 +26,49 @@ export function RewardClaimScreen() {
   const [email, setEmail] = useState(user?.email ?? '');
   const [phone, setPhone] = useState('');
   const [emailError, setEmailError] = useState('');
+  const [sponsors, setSponsors] = useState<Sponsor[]>([]);
+  const [selectedSponsorId, setSelectedSponsorId] = useState<string | null>(
+    null,
+  );
+  const [sponsorError, setSponsorError] = useState('');
+  const [isLoadingSponsors, setIsLoadingSponsors] = useState(true);
+
+  useEffect(() => {
+    const sponsorIds =
+      session?.sponsorIds && session.sponsorIds.length > 0
+        ? session.sponsorIds
+        : session?.sponsorId
+          ? [session.sponsorId]
+          : [];
+
+    if (sponsorIds.length === 0) {
+      setSponsors([]);
+      setSelectedSponsorId(null);
+      setIsLoadingSponsors(false);
+      return;
+    }
+
+    setIsLoadingSponsors(true);
+    Promise.all(
+      sponsorIds.map(async (sponsorId) => {
+        const snap = await getDoc(doc(db, COLLECTIONS.SPONSORS, sponsorId));
+        if (!snap.exists()) return null;
+        return { id: snap.id, ...(snap.data() as Omit<Sponsor, 'id'>) };
+      }),
+    )
+      .then((loadedSponsors) => {
+        const nextSponsors = loadedSponsors.filter(
+          (s): s is Sponsor => s !== null,
+        );
+        setSponsors(nextSponsors);
+        setSelectedSponsorId((prev) =>
+          prev && nextSponsors.some((sponsor) => sponsor.id === prev)
+            ? prev
+            : nextSponsors[0]?.id ?? null,
+        );
+      })
+      .finally(() => setIsLoadingSponsors(false));
+  }, [session?.sponsorId, session?.sponsorIds]);
 
   function validateEmail(value: string): boolean {
     const trimmed = value.trim();
@@ -39,12 +86,17 @@ export function RewardClaimScreen() {
 
   async function handleSubmit() {
     if (!validateEmail(email)) return;
-    if (!user?.uid || !session?.sponsorId) return;
+    if (!selectedSponsorId) {
+      setSponsorError('Please select a reward first.');
+      return;
+    }
+    if (!user?.uid) return;
 
+    setSponsorError('');
     await submit(
       user.uid,
       sessionId,
-      session.sponsorId,
+      selectedSponsorId,
       email,
       phone.trim() || null,
     );
@@ -83,10 +135,50 @@ export function RewardClaimScreen() {
 
       <Text style={styles.title}>Claim Your Reward</Text>
       <Text style={styles.subtitle}>
-        Confirm your contact details so the sponsor can reach you.
+        Choose your reward, then confirm your contact details.
       </Text>
 
       <Card style={styles.formCard}>
+        <Text style={styles.sectionLabel}>Choose a Sponsor Reward</Text>
+        {isLoadingSponsors ? (
+          <ActivityIndicator color={AppColors.accent} style={styles.spinner} />
+        ) : sponsors.length === 0 ? (
+          <Text style={styles.emptySponsors}>
+            No sponsor rewards are configured for this session.
+          </Text>
+        ) : (
+          sponsors.map((sponsor) => {
+            const selected = selectedSponsorId === sponsor.id;
+            return (
+              <Pressable
+                key={sponsor.id}
+                onPress={() => {
+                  setSelectedSponsorId(sponsor.id);
+                  if (sponsorError) setSponsorError('');
+                }}
+                style={({ pressed }) => [pressed && styles.pressed]}
+                accessibilityRole="radio"
+                accessibilityState={{ checked: selected }}
+              >
+                <Card
+                  style={[
+                    styles.sponsorOptionCard,
+                    selected ? styles.sponsorOptionSelected : null,
+                  ]}
+                >
+                  <Text style={styles.sponsorName}>{sponsor.name}</Text>
+                  {!!sponsor.rewardDescription && (
+                    <Text style={styles.sponsorRewardText}>
+                      {sponsor.rewardDescription}
+                    </Text>
+                  )}
+                </Card>
+              </Pressable>
+            );
+          })
+        )}
+        {sponsorError ? <Text style={styles.errorText}>{sponsorError}</Text> : null}
+
         <TextField
           label="Email Address"
           value={email}
@@ -147,6 +239,43 @@ const styles = StyleSheet.create({
   formCard: {
     backgroundColor: AppColors.bgElevated,
     gap: Spacing.base,
+  },
+  sectionLabel: {
+    ...Typography.label,
+    color: AppColors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  spinner: {
+    marginVertical: Spacing.xs,
+  },
+  emptySponsors: {
+    ...Typography.bodySmall,
+    color: AppColors.textMuted,
+    fontStyle: 'italic',
+  },
+  sponsorOptionCard: {
+    backgroundColor: AppColors.bgPrimary,
+    borderColor: AppColors.borderSubtle,
+    marginBottom: Spacing.xs,
+    gap: Spacing.xs,
+  },
+  sponsorOptionSelected: {
+    borderColor: AppColors.accent,
+    borderWidth: 2,
+    backgroundColor: AppColors.accentSoft,
+  },
+  pressed: {
+    opacity: 0.8,
+  },
+  sponsorName: {
+    ...Typography.body,
+    color: AppColors.textPrimary,
+    fontWeight: '600',
+  },
+  sponsorRewardText: {
+    ...Typography.bodySmall,
+    color: AppColors.textSecondary,
   },
   privacyNote: {
     ...Typography.bodySmall,

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -30,6 +30,7 @@ export interface AuthContextValue {
     teamId: string | null,
   ) => Promise<void>;
   signOut: () => Promise<void>;
+  setUserTeam: (teamId: string | null) => void;
 }
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
@@ -89,9 +90,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setFirebaseUser(null);
   }, []);
 
+  const setUserTeam = useCallback((teamId: string | null) => {
+    setUser((prev) => (prev ? { ...prev, teamId } : prev));
+  }, []);
+
   const value = useMemo<AuthContextValue>(
-    () => ({ user, firebaseUser, isLoading, signIn, signUp, signOut }),
-    [user, firebaseUser, isLoading, signIn, signUp, signOut],
+    () => ({
+      user,
+      firebaseUser,
+      isLoading,
+      signIn,
+      signUp,
+      signOut,
+      setUserTeam,
+    }),
+    [user, firebaseUser, isLoading, signIn, signUp, signOut, setUserTeam],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -21,5 +21,6 @@ export interface GameSession {
   teamIds: string[];
   questionOrder: string[];
   currentQuestionIndex: number;
+  scoredQuestionIds?: string[];
   createdAt: Timestamp;
 }

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -10,7 +10,8 @@ export interface GameSession {
   currentQuestionId: string | null;
   questionActive: boolean;
   questionStartTime: Timestamp | null;
-  sponsorId: string;
+  sponsorIds: string[];
+  sponsorId?: string;
   settings: {
     showTeamScores: boolean;
     allowLateJoin: boolean;


### PR DESCRIPTION
## Summary
- move authoritative scoring from fan clients into the admin close-question flow so scoring is deterministic and participation-normalized
- award each team question points using percentage correct (`round((correct/total) * questionPoints)`) instead of raw correct count
- keep scoring idempotent by tracking `scoredQuestionIds` on sessions to prevent duplicate increments

## Test plan
- [x] Start a session and answer a question with different fan counts per team but equal correct percentages; verify both teams receive equal points
- [x] Verify uneven percentages produce proportional points (for example 75% vs 25%)
- [x] Verify a team with zero answers gets 0 points for that question
- [x] Verify repeated close-question actions do not double-add team scores
- [ ] closes #33 