### PR TITLE
[PULL REQUEST] Add Fan Opt-in and Strict Session Team Switch

### DIFF
--- a/src/app/(fan)/_layout.tsx
+++ b/src/app/(fan)/_layout.tsx
@@ -8,6 +8,7 @@ export default function FanLayout() {
     <ErrorBoundary>
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="game-selection" />
+        <Stack.Screen name="settings" />
         <Stack.Screen name="team-selection" />
         <Stack.Screen name="[sessionId]" />
       </Stack>

--- a/src/app/(fan)/settings.tsx
+++ b/src/app/(fan)/settings.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import { FanSettingsScreen } from '@/features/auth/components/FanSettingsScreen';
+
+export default function FanSettingsRoute() {
+  return <FanSettingsScreen />;
+}

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -3,7 +3,7 @@ import {
   DefaultTheme,
   ThemeProvider,
 } from '@react-navigation/native';
-import { useRouter, Stack } from 'expo-router';
+import { useRouter, Stack, useSegments } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import React, { useEffect } from 'react';
 import 'react-native-reanimated';
@@ -15,17 +15,25 @@ import { useAuth } from '@/features/auth/hooks/useAuth';
 function RoleGatekeeper({ children }: { children: React.ReactNode }) {
   const { user, isLoading } = useAuth();
   const router = useRouter();
+  const segments = useSegments();
+  const topSegment = segments[0];
 
   useEffect(() => {
     if (isLoading) return;
     if (!user) {
-      router.replace('/(auth)/login');
+      if (topSegment !== '(auth)') {
+        router.replace('/(auth)/login');
+      }
     } else if (user.role === 'admin') {
-      router.replace('/(admin)/dashboard');
+      if (topSegment !== '(admin)') {
+        router.replace('/(admin)/dashboard');
+      }
     } else {
-      router.replace('/(fan)/game-selection');
+      if (topSegment !== '(fan)') {
+        router.replace('/(fan)/game-selection');
+      }
     }
-  }, [user, isLoading, router]);
+  }, [user, isLoading, router, topSegment]);
 
   return <>{children}</>;
 }

--- a/src/constants/firestore.ts
+++ b/src/constants/firestore.ts
@@ -1,6 +1,7 @@
 export const COLLECTIONS = {
   USERS: 'users',
   GAME_SESSIONS: 'game_sessions',
+  SESSION_PARTICIPANTS: 'session_participants',
   QUESTIONS: 'questions',
   SUBMISSIONS: 'submissions',
   TEAMS: 'teams',

--- a/src/features/admin/components/SessionSetupScreen.tsx
+++ b/src/features/admin/components/SessionSetupScreen.tsx
@@ -39,10 +39,8 @@ export function SessionSetupScreen() {
   // Question selection (ordered list)
   const [selectedQuestionIds, setSelectedQuestionIds] = useState<string[]>([]);
 
-  // Sponsor selection (one)
-  const [selectedSponsorId, setSelectedSponsorId] = useState<string | null>(
-    null,
-  );
+  // Sponsor selection (one or more)
+  const [selectedSponsorIds, setSelectedSponsorIds] = useState<string[]>([]);
   const [showNewSponsor, setShowNewSponsor] = useState(false);
   const [newSponsorName, setNewSponsorName] = useState('');
   const [newSponsorReward, setNewSponsorReward] = useState('');
@@ -96,6 +94,12 @@ export function SessionSetupScreen() {
   }
 
   // ── Sponsor helpers ──
+  function toggleSponsor(id: string) {
+    setSelectedSponsorIds((prev) =>
+      prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id],
+    );
+  }
+
   async function handleAddSponsor() {
     if (!newSponsorName.trim()) {
       setNewSponsorError('Sponsor name is required.');
@@ -108,7 +112,9 @@ export function SessionSetupScreen() {
         newSponsorName.trim(),
         newSponsorReward.trim(),
       );
-      setSelectedSponsorId(created.id);
+      setSelectedSponsorIds((prev) =>
+        prev.includes(created.id) ? prev : [...prev, created.id],
+      );
       setNewSponsorName('');
       setNewSponsorReward('');
       setShowNewSponsor(false);
@@ -123,7 +129,7 @@ export function SessionSetupScreen() {
   function validate(): string | null {
     if (selectedTeamIds.length !== 2) return 'Select exactly 2 teams.';
     if (selectedQuestionIds.length === 0) return 'Select at least 1 question.';
-    if (!selectedSponsorId) return 'Select a sponsor.';
+    if (selectedSponsorIds.length === 0) return 'Select at least 1 sponsor.';
     return null;
   }
 
@@ -139,7 +145,7 @@ export function SessionSetupScreen() {
       await createSession({
         teamIds: selectedTeamIds,
         questionOrder: selectedQuestionIds,
-        sponsorId: selectedSponsorId!,
+        sponsorIds: selectedSponsorIds,
         settings: { showTeamScores, allowLateJoin },
       });
       router.replace('/(admin)/dashboard');
@@ -164,7 +170,7 @@ export function SessionSetupScreen() {
         </Pressable>
         <Text style={styles.title}>New Session</Text>
         <Text style={styles.subtitle}>
-          Configure teams, questions, sponsor, and settings.
+          Configure teams, questions, sponsors, and settings.
         </Text>
       </View>
 
@@ -316,21 +322,24 @@ export function SessionSetupScreen() {
         )}
       </View>
 
-      {/* ── Section 3: Sponsor ── */}
+      {/* ── Section 3: Sponsors ── */}
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Select Sponsor</Text>
+        <Text style={styles.sectionTitle}>Select Sponsors</Text>
+        <Text style={styles.sectionHint}>
+          Winners can choose from these rewards at the end.
+        </Text>
 
         {sponsorsLoading ? (
           <ActivityIndicator color={AppColors.accent} style={styles.spinner} />
         ) : (
           sponsors.map((sponsor: Sponsor) => {
-            const selected = selectedSponsorId === sponsor.id;
+            const selected = selectedSponsorIds.includes(sponsor.id);
             return (
               <Pressable
                 key={sponsor.id}
-                onPress={() => setSelectedSponsorId(sponsor.id)}
+                onPress={() => toggleSponsor(sponsor.id)}
                 style={({ pressed }) => (pressed ? styles.pressed : undefined)}
-                accessibilityRole="radio"
+                accessibilityRole="checkbox"
                 accessibilityState={{ checked: selected }}
               >
                 <Card

--- a/src/features/admin/components/SessionSetupScreen.tsx
+++ b/src/features/admin/components/SessionSetupScreen.tsx
@@ -28,6 +28,7 @@ export function SessionSetupScreen() {
   const { teams, isLoading: teamsLoading } = useTeams();
   const { sponsors, isLoading: sponsorsLoading } = useSponsors();
   const { questions, isLoading: questionsLoading } = useQuestions();
+  const [sessionTitle, setSessionTitle] = useState('Game Session');
 
   // Team selection (exactly 2)
   const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
@@ -127,6 +128,7 @@ export function SessionSetupScreen() {
 
   // ── Submit ──
   function validate(): string | null {
+    if (!sessionTitle.trim()) return 'Session title is required.';
     if (selectedTeamIds.length !== 2) return 'Select exactly 2 teams.';
     if (selectedQuestionIds.length === 0) return 'Select at least 1 question.';
     if (selectedSponsorIds.length === 0) return 'Select at least 1 sponsor.';
@@ -143,6 +145,7 @@ export function SessionSetupScreen() {
     setSubmitError('');
     try {
       await createSession({
+        title: sessionTitle.trim(),
         teamIds: selectedTeamIds,
         questionOrder: selectedQuestionIds,
         sponsorIds: selectedSponsorIds,
@@ -172,6 +175,17 @@ export function SessionSetupScreen() {
         <Text style={styles.subtitle}>
           Configure teams, questions, sponsors, and settings.
         </Text>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Session Details</Text>
+        <TextField
+          label="Game Title"
+          value={sessionTitle}
+          onChangeText={setSessionTitle}
+          placeholder="e.g. Knicks Halftime Trivia"
+          maxLength={60}
+        />
       </View>
 
       {/* ── Section 1: Teams ── */}

--- a/src/features/admin/services/sessionService.ts
+++ b/src/features/admin/services/sessionService.ts
@@ -20,7 +20,7 @@ import { type GameSession, type Question } from '@/types';
 export interface CreateSessionInput {
   teamIds: string[];
   questionOrder: string[];
-  sponsorId: string;
+  sponsorIds: string[];
   settings: {
     showTeamScores: boolean;
     allowLateJoin: boolean;
@@ -34,7 +34,7 @@ export async function createSession(data: CreateSessionInput): Promise<string> {
       currentQuestionId: null,
       questionActive: false,
       questionStartTime: null,
-      sponsorId: data.sponsorId,
+      sponsorIds: data.sponsorIds,
       settings: data.settings,
       currentQuestion: null,
       correctOptionId: null,

--- a/src/features/admin/services/sessionService.ts
+++ b/src/features/admin/services/sessionService.ts
@@ -18,6 +18,7 @@ import { resetSessionScores } from '@/features/teams/services/teamService';
 import { type GameSession, type Question } from '@/types';
 
 export interface CreateSessionInput {
+  title: string;
   teamIds: string[];
   questionOrder: string[];
   sponsorIds: string[];
@@ -30,6 +31,7 @@ export interface CreateSessionInput {
 export async function createSession(data: CreateSessionInput): Promise<string> {
   const [ref] = await Promise.all([
     addDoc(collection(db, COLLECTIONS.GAME_SESSIONS), {
+      title: data.title,
       status: 'lobby',
       currentQuestionId: null,
       questionActive: false,

--- a/src/features/auth/components/FanSettingsScreen.tsx
+++ b/src/features/auth/components/FanSettingsScreen.tsx
@@ -1,0 +1,132 @@
+import { useRouter } from 'expo-router';
+import React, { useState } from 'react';
+import { Pressable, StyleSheet, Switch, Text, View } from 'react-native';
+
+import { Button } from '@/components/ui/Button';
+import { Card } from '@/components/ui/Card';
+import { ScreenContainer } from '@/components/ui/ScreenContainer';
+import { AppColors, Spacing, Typography } from '@/constants/theme';
+import { useAuth } from '@/features/auth/hooks/useAuth';
+import { updateUserMarketingOptIn } from '@/features/auth/services/authService';
+
+export function FanSettingsScreen() {
+  const router = useRouter();
+  const { user, setUserMarketingOptIn } = useAuth();
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleToggleMarketing(nextValue: boolean) {
+    if (!user || isSaving) return;
+    const prevValue = user.marketingOptIn;
+    setError(null);
+    setIsSaving(true);
+    setUserMarketingOptIn(nextValue);
+    try {
+      await updateUserMarketingOptIn(user.uid, nextValue);
+    } catch {
+      setUserMarketingOptIn(prevValue);
+      setError('Failed to update your preference. Please try again.');
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <ScreenContainer>
+      <Pressable
+        onPress={() => router.back()}
+        style={styles.backButton}
+        accessibilityRole="button"
+        accessibilityLabel="Go back"
+      >
+        <Text style={styles.backText}>‹ Back</Text>
+      </Pressable>
+
+      <Text style={styles.title}>Fan Settings</Text>
+      <Text style={styles.subtitle}>Update your preferences anytime.</Text>
+
+      <Card style={styles.card}>
+        <View style={styles.row}>
+          <View style={styles.copy}>
+            <Text style={styles.label}>Marketing Opt-In</Text>
+            <Text style={styles.hint}>
+              Enable this to stay eligible for sponsor rewards.
+            </Text>
+          </View>
+          <Switch
+            value={user?.marketingOptIn ?? false}
+            onValueChange={handleToggleMarketing}
+            disabled={!user || isSaving}
+            trackColor={{
+              false: AppColors.borderSubtle,
+              true: AppColors.accent,
+            }}
+            thumbColor={AppColors.bgSecondary}
+          />
+        </View>
+      </Card>
+
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+
+      <Button
+        label="Back to Games"
+        variant="secondary"
+        onPress={() => router.replace('/(fan)/game-selection')}
+        style={styles.cta}
+      />
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  backButton: {
+    alignSelf: 'flex-start',
+    minHeight: 44,
+    justifyContent: 'center',
+    marginBottom: Spacing.sm,
+  },
+  backText: {
+    ...Typography.body,
+    color: AppColors.accent,
+  },
+  title: {
+    ...Typography.headingL,
+    color: AppColors.textPrimary,
+  },
+  subtitle: {
+    ...Typography.body,
+    color: AppColors.textMuted,
+    marginTop: Spacing.xs,
+    marginBottom: Spacing.lg,
+  },
+  card: {
+    backgroundColor: AppColors.bgElevated,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: Spacing.base,
+  },
+  copy: {
+    flex: 1,
+    gap: Spacing.xs,
+  },
+  label: {
+    ...Typography.headingM,
+    color: AppColors.textPrimary,
+  },
+  hint: {
+    ...Typography.bodySmall,
+    color: AppColors.textMuted,
+  },
+  error: {
+    ...Typography.bodySmall,
+    color: AppColors.danger,
+    marginTop: Spacing.sm,
+    textAlign: 'center',
+  },
+  cta: {
+    marginTop: Spacing.lg,
+  },
+});

--- a/src/features/auth/services/authService.ts
+++ b/src/features/auth/services/authService.ts
@@ -47,3 +47,10 @@ export async function updateUserTeam(
 ): Promise<void> {
   await updateDoc(doc(db, COLLECTIONS.USERS, uid), { teamId });
 }
+
+export async function updateUserMarketingOptIn(
+  uid: string,
+  marketingOptIn: boolean,
+): Promise<void> {
+  await updateDoc(doc(db, COLLECTIONS.USERS, uid), { marketingOptIn });
+}

--- a/src/features/game/components/GameSelectionScreen.tsx
+++ b/src/features/game/components/GameSelectionScreen.tsx
@@ -28,7 +28,9 @@ function SessionCard({
     >
       <View style={styles.sessionCardRow}>
         <View style={styles.sessionCardInfo}>
-          <Text style={styles.sessionTitle}>Game Session</Text>
+          <Text style={styles.sessionTitle}>
+            {session.title?.trim() || 'Game Session'}
+          </Text>
           <Text style={styles.sessionMeta}>
             {session.teamIds?.length ?? 0} teams •{' '}
             {session.questionOrder?.length ?? 0} questions

--- a/src/features/game/components/GameSelectionScreen.tsx
+++ b/src/features/game/components/GameSelectionScreen.tsx
@@ -94,12 +94,20 @@ export function GameSelectionScreen() {
             Welcome, {user?.displayName ?? 'Fan'}
           </Text>
         </View>
-        <Button
-          label="Sign Out"
-          variant="ghost"
-          fullWidth={false}
-          onPress={handleSignOut}
-        />
+        <View style={styles.headerActions}>
+          <Button
+            label="Settings"
+            variant="ghost"
+            fullWidth={false}
+            onPress={() => router.push('/(fan)/settings')}
+          />
+          <Button
+            label="Sign Out"
+            variant="ghost"
+            fullWidth={false}
+            onPress={handleSignOut}
+          />
+        </View>
       </View>
 
       {isLoading ? (
@@ -141,6 +149,11 @@ const styles = StyleSheet.create({
     marginBottom: Spacing.lg,
   },
   headerText: {
+    gap: Spacing.xs,
+  },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
     gap: Spacing.xs,
   },
   title: {

--- a/src/features/game/components/LobbyScreen.tsx
+++ b/src/features/game/components/LobbyScreen.tsx
@@ -11,6 +11,7 @@ import { AppColors, Spacing, Typography } from '@/constants/theme';
 import { COLLECTIONS } from '@/constants/firestore';
 import { db } from '@/api/firebase';
 import { useAuth } from '@/features/auth/hooks/useAuth';
+import { getSessionParticipant } from '@/features/game/services/sessionParticipantService';
 import { useGameState } from '@/providers/GameStateProvider';
 import { type Sponsor, type Team } from '@/types';
 
@@ -68,6 +69,7 @@ export function LobbyScreen() {
   const { user } = useAuth();
   const { session, teams, isLoading } = useGameState();
   const [sponsors, setSponsors] = useState<Sponsor[]>([]);
+  const [sessionTeamId, setSessionTeamId] = useState<string | null>(null);
 
   useEffect(() => {
     const sponsorIds =
@@ -91,6 +93,20 @@ export function LobbyScreen() {
       setSponsors(loadedSponsors.filter((s): s is Sponsor => s !== null));
     });
   }, [session?.sponsorId, session?.sponsorIds]);
+
+  useEffect(() => {
+    if (!session?.id || !user?.uid) {
+      setSessionTeamId(null);
+      return;
+    }
+    getSessionParticipant(session.id, user.uid)
+      .then((participant) => {
+        setSessionTeamId(participant?.teamId ?? user.teamId ?? null);
+      })
+      .catch(() => {
+        setSessionTeamId(user.teamId ?? null);
+      });
+  }, [session?.id, user?.uid, user?.teamId]);
 
   const sortedTeams = [...teams].sort(
     (a, b) => b.currentSessionScore - a.currentSessionScore,
@@ -127,6 +143,18 @@ export function LobbyScreen() {
         />
       </View>
 
+      <Button
+        label="Change Team"
+        variant="secondary"
+        onPress={() =>
+          router.push({
+            pathname: '/(fan)/team-selection',
+            params: { sessionId: session.id },
+          })
+        }
+        style={styles.changeTeamBtn}
+      />
+
       {sponsors.map((sponsor) => (
         <SponsorCard key={sponsor.id} sponsor={sponsor} />
       ))}
@@ -140,7 +168,7 @@ export function LobbyScreen() {
                 <TeamScoreRow
                   team={team}
                   rank={index + 1}
-                  isUserTeam={team.id === user?.teamId}
+                  isUserTeam={team.id === sessionTeamId}
                 />
                 {index < sortedTeams.length - 1 && (
                   <View style={styles.divider} />
@@ -197,6 +225,9 @@ const styles = StyleSheet.create({
     backgroundColor: AppColors.bgElevated,
     marginBottom: Spacing.lg,
     gap: Spacing.xs,
+  },
+  changeTeamBtn: {
+    marginBottom: Spacing.base,
   },
   sponsorLabel: {
     ...Typography.label,

--- a/src/features/game/components/LobbyScreen.tsx
+++ b/src/features/game/components/LobbyScreen.tsx
@@ -67,16 +67,30 @@ export function LobbyScreen() {
   const router = useRouter();
   const { user } = useAuth();
   const { session, teams, isLoading } = useGameState();
-  const [sponsor, setSponsor] = useState<Sponsor | null>(null);
+  const [sponsors, setSponsors] = useState<Sponsor[]>([]);
 
   useEffect(() => {
-    if (!session?.sponsorId) return;
-    getDoc(doc(db, COLLECTIONS.SPONSORS, session.sponsorId)).then((snap) => {
-      if (snap.exists()) {
-        setSponsor({ id: snap.id, ...(snap.data() as Omit<Sponsor, 'id'>) });
-      }
+    const sponsorIds =
+      session?.sponsorIds && session.sponsorIds.length > 0
+        ? session.sponsorIds
+        : session?.sponsorId
+          ? [session.sponsorId]
+          : [];
+    if (sponsorIds.length === 0) {
+      setSponsors([]);
+      return;
+    }
+
+    Promise.all(
+      sponsorIds.map(async (sponsorId) => {
+        const snap = await getDoc(doc(db, COLLECTIONS.SPONSORS, sponsorId));
+        if (!snap.exists()) return null;
+        return { id: snap.id, ...(snap.data() as Omit<Sponsor, 'id'>) };
+      }),
+    ).then((loadedSponsors) => {
+      setSponsors(loadedSponsors.filter((s): s is Sponsor => s !== null));
     });
-  }, [session?.sponsorId]);
+  }, [session?.sponsorId, session?.sponsorIds]);
 
   const sortedTeams = [...teams].sort(
     (a, b) => b.currentSessionScore - a.currentSessionScore,
@@ -113,7 +127,9 @@ export function LobbyScreen() {
         />
       </View>
 
-      {sponsor ? <SponsorCard sponsor={sponsor} /> : null}
+      {sponsors.map((sponsor) => (
+        <SponsorCard key={sponsor.id} sponsor={sponsor} />
+      ))}
 
       {session.settings.showTeamScores && sortedTeams.length > 0 ? (
         <View style={styles.scoresSection}>

--- a/src/features/game/components/QuestionScreen.tsx
+++ b/src/features/game/components/QuestionScreen.tsx
@@ -11,6 +11,7 @@ import {
 import { ScreenContainer } from '@/components/ui/ScreenContainer';
 import { AppColors, Spacing, Typography } from '@/constants/theme';
 import { useAuth } from '@/features/auth/hooks/useAuth';
+import { resolveSessionTeamForAnswer } from '@/features/game/services/sessionParticipantService';
 import { useCountdown } from '@/features/game/hooks/useCountdown';
 import { submitAnswer } from '@/features/game/services/submissionService';
 import { useGameState } from '@/providers/GameStateProvider';
@@ -107,8 +108,7 @@ export function QuestionScreen() {
       submitted ||
       isSubmitting ||
       !user ||
-      !session?.currentQuestionId ||
-      !user.teamId
+      !session?.currentQuestionId
     )
       return;
     setSelectedOptionId(optionId);
@@ -116,11 +116,16 @@ export function QuestionScreen() {
     setError(null);
 
     try {
+      const teamId = await resolveSessionTeamForAnswer(
+        sessionId,
+        user.uid,
+        user.teamId,
+      );
       await submitAnswer(
         sessionId,
         session.currentQuestionId,
         user.uid,
-        user.teamId,
+        teamId,
         optionId,
       );
       setSubmitted(true);
@@ -128,8 +133,12 @@ export function QuestionScreen() {
         pathname: '/(fan)/[sessionId]/waiting',
         params: { sessionId },
       });
-    } catch {
-      setError('Failed to submit answer. Please try again.');
+    } catch (e) {
+      setError(
+        e instanceof Error
+          ? e.message
+          : 'Failed to submit answer. Please try again.',
+      );
       setSelectedOptionId(null);
       setIsSubmitting(false);
     }

--- a/src/features/game/components/QuestionScreen.tsx
+++ b/src/features/game/components/QuestionScreen.tsx
@@ -103,7 +103,13 @@ export function QuestionScreen() {
   }, [isQuestionActive, submitted, router, sessionId]);
 
   async function handleSelectOption(optionId: string) {
-    if (submitted || isSubmitting || !user || !session?.currentQuestionId)
+    if (
+      submitted ||
+      isSubmitting ||
+      !user ||
+      !session?.currentQuestionId ||
+      !user.teamId
+    )
       return;
     setSelectedOptionId(optionId);
     setIsSubmitting(true);
@@ -114,7 +120,7 @@ export function QuestionScreen() {
         sessionId,
         session.currentQuestionId,
         user.uid,
-        user.teamId ?? '',
+        user.teamId,
         optionId,
       );
       setSubmitted(true);

--- a/src/features/game/components/ResultsScreen.tsx
+++ b/src/features/game/components/ResultsScreen.tsx
@@ -96,10 +96,17 @@ export function ResultsScreen() {
     (a, b) => b.currentSessionScore - a.currentSessionScore,
   );
   const winningTeam = sortedTeams[0] ?? null;
+  const sponsorCount =
+    session?.sponsorIds && session.sponsorIds.length > 0
+      ? session.sponsorIds.length
+      : session?.sponsorId
+        ? 1
+        : 0;
 
   const isOnWinningTeam =
     winningTeam !== null && user?.teamId === winningTeam.id;
-  const canClaimReward = isOnWinningTeam && user?.marketingOptIn === true;
+  const canClaimReward =
+    isOnWinningTeam && user?.marketingOptIn === true && sponsorCount > 0;
 
   function handleClaimReward() {
     router.push({
@@ -156,7 +163,8 @@ export function ResultsScreen() {
       {canClaimReward && (
         <View style={styles.rewardSection}>
           <Text style={styles.rewardHint}>
-            You qualified for a sponsor reward. Claim it below!
+            You qualified for a sponsor reward. Choose your reward and claim it
+            below!
           </Text>
           <Button
             label="Claim Your Reward"
@@ -175,9 +183,10 @@ export function ResultsScreen() {
         </Card>
       )}
 
-      {!session?.sponsorId ? null : (
+      {sponsorCount === 0 ? null : (
         <Text style={styles.sponsorLine}>
-          Powered by your sponsor · Session {sessionId}
+          Powered by {sponsorCount} sponsor{sponsorCount === 1 ? '' : 's'} ·
+          Session {sessionId}
         </Text>
       )}
 

--- a/src/features/game/components/TeamSelectionScreen.tsx
+++ b/src/features/game/components/TeamSelectionScreen.tsx
@@ -1,5 +1,5 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   FlatList,
@@ -14,6 +14,11 @@ import { ScreenContainer } from '@/components/ui/ScreenContainer';
 import { AppColors, Spacing, Typography } from '@/constants/theme';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import { updateUserTeam } from '@/features/auth/services/authService';
+import {
+  canChangeSessionTeam,
+  getSessionParticipant,
+  upsertSessionTeamStrict,
+} from '@/features/game/services/sessionParticipantService';
 import { useTeams } from '@/features/teams/hooks/useTeams';
 import { type Team } from '@/types';
 
@@ -56,14 +61,37 @@ export function TeamSelectionScreen() {
   const { user, setUserTeam } = useAuth();
   const { teams, isLoading } = useTeams();
   const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
+  const [isCheckingLock, setIsCheckingLock] = useState(true);
+  const [isLocked, setIsLocked] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  useEffect(() => {
+    if (!user) return;
+    setIsCheckingLock(true);
+    setError(null);
+    Promise.all([
+      getSessionParticipant(sessionId, user.uid),
+      canChangeSessionTeam(sessionId, user.uid),
+    ])
+      .then(([participant, canChange]) => {
+        setSelectedTeamId(participant?.teamId ?? user.teamId ?? null);
+        setIsLocked(!canChange);
+      })
+      .catch(() => {
+        setError('Failed to load your team selection. Please try again.');
+      })
+      .finally(() => {
+        setIsCheckingLock(false);
+      });
+  }, [sessionId, user]);
+
   async function handleConfirm() {
-    if (!selectedTeamId || !user) return;
+    if (!selectedTeamId || !user || isLocked) return;
     setIsSaving(true);
     setError(null);
     try {
+      await upsertSessionTeamStrict(sessionId, user.uid, selectedTeamId);
       await updateUserTeam(user.uid, selectedTeamId);
       setUserTeam(selectedTeamId);
       router.replace({
@@ -90,11 +118,12 @@ export function TeamSelectionScreen() {
         </Pressable>
         <Text style={styles.title}>Pick Your Team</Text>
         <Text style={styles.subtitle}>
-          Choose the team you want to cheer for. You can change this later.
+          Choose your team for this session. Team changes lock after your first
+          answer.
         </Text>
       </View>
 
-      {isLoading ? (
+      {isLoading || isCheckingLock ? (
         <View style={styles.center}>
           <ActivityIndicator color={AppColors.accent} size="large" />
         </View>
@@ -119,9 +148,9 @@ export function TeamSelectionScreen() {
 
       <View style={styles.footer}>
         <Button
-          label="Join Game"
+          label={isLocked ? 'Team Locked' : 'Save Team'}
           onPress={handleConfirm}
-          disabled={!selectedTeamId}
+          disabled={!selectedTeamId || isLocked}
           loading={isSaving}
         />
       </View>

--- a/src/features/game/components/TeamSelectionScreen.tsx
+++ b/src/features/game/components/TeamSelectionScreen.tsx
@@ -53,7 +53,7 @@ function TeamRow({
 export function TeamSelectionScreen() {
   const router = useRouter();
   const { sessionId } = useLocalSearchParams<{ sessionId: string }>();
-  const { user } = useAuth();
+  const { user, setUserTeam } = useAuth();
   const { teams, isLoading } = useTeams();
   const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
@@ -65,6 +65,7 @@ export function TeamSelectionScreen() {
     setError(null);
     try {
       await updateUserTeam(user.uid, selectedTeamId);
+      setUserTeam(selectedTeamId);
       router.replace({
         pathname: '/(fan)/[sessionId]/lobby',
         params: { sessionId },

--- a/src/features/game/components/WaitingScreen.tsx
+++ b/src/features/game/components/WaitingScreen.tsx
@@ -30,7 +30,6 @@ export function WaitingScreen() {
       !lockedQuestionIdRef.current ||
       scoreScoredRef.current ||
       !user?.uid ||
-      !user?.teamId ||
       !currentQuestion
     ) {
       return;
@@ -42,7 +41,7 @@ export function WaitingScreen() {
 
     const questionId = lockedQuestionIdRef.current;
     const submissionId = `${sessionId}_${questionId}_${user.uid}`;
-    const { uid, teamId } = user;
+    const { uid } = user;
     const { points } = currentQuestion;
     const revealedOptionId = correctOptionId;
 
@@ -54,17 +53,18 @@ export function WaitingScreen() {
         }
         const data = snap.data();
         const selected = data.selectedOptionId as string;
+        const submissionTeamId = data.teamId as string | undefined;
 
         setIsCorrect(selected === revealedOptionId);
 
-        if (data.isCorrect === null) {
+        if (data.isCorrect === null && submissionTeamId) {
           computeAndRecordScore(
             submissionId,
             selected,
             revealedOptionId,
             points,
             uid,
-            teamId!,
+            submissionTeamId,
           ).catch(() => {
             scoreScoredRef.current = false;
           });

--- a/src/features/game/services/sessionParticipantService.ts
+++ b/src/features/game/services/sessionParticipantService.ts
@@ -1,0 +1,96 @@
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  limit,
+  query,
+  serverTimestamp,
+  setDoc,
+  where,
+} from 'firebase/firestore';
+
+import { db } from '@/api/firebase';
+import { COLLECTIONS } from '@/constants/firestore';
+import { type SessionParticipant } from '@/types';
+
+function participantDocId(sessionId: string, uid: string): string {
+  return `${sessionId}_${uid}`;
+}
+
+export async function getSessionParticipant(
+  sessionId: string,
+  uid: string,
+): Promise<SessionParticipant | null> {
+  const ref = doc(
+    db,
+    COLLECTIONS.SESSION_PARTICIPANTS,
+    participantDocId(sessionId, uid),
+  );
+  const snap = await getDoc(ref);
+  if (!snap.exists()) return null;
+  return {
+    id: snap.id,
+    ...(snap.data() as Omit<SessionParticipant, 'id'>),
+  };
+}
+
+export async function canChangeSessionTeam(
+  sessionId: string,
+  uid: string,
+): Promise<boolean> {
+  const submissionsQuery = query(
+    collection(db, COLLECTIONS.SUBMISSIONS),
+    where('sessionId', '==', sessionId),
+    where('uid', '==', uid),
+    limit(1),
+  );
+  const submissionsSnap = await getDocs(submissionsQuery);
+  return submissionsSnap.empty;
+}
+
+export async function upsertSessionTeamStrict(
+  sessionId: string,
+  uid: string,
+  teamId: string,
+): Promise<void> {
+  const isAllowed = await canChangeSessionTeam(sessionId, uid);
+  if (!isAllowed) {
+    throw new Error(
+      'Team changes are locked after your first answer in this session.',
+    );
+  }
+
+  const ref = doc(
+    db,
+    COLLECTIONS.SESSION_PARTICIPANTS,
+    participantDocId(sessionId, uid),
+  );
+  const existing = await getDoc(ref);
+  await setDoc(
+    ref,
+    {
+      sessionId,
+      uid,
+      teamId,
+      joinedAt: existing.exists() ? existing.data().joinedAt : serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    },
+    { merge: true },
+  );
+}
+
+export async function resolveSessionTeamForAnswer(
+  sessionId: string,
+  uid: string,
+  fallbackTeamId: string | null,
+): Promise<string> {
+  const participant = await getSessionParticipant(sessionId, uid);
+  if (participant?.teamId) return participant.teamId;
+  if (!fallbackTeamId) {
+    throw new Error('Pick a team before submitting an answer.');
+  }
+
+  await upsertSessionTeamStrict(sessionId, uid, fallbackTeamId);
+  return fallbackTeamId;
+}

--- a/src/features/rewards/components/RewardClaimScreen.tsx
+++ b/src/features/rewards/components/RewardClaimScreen.tsx
@@ -1,15 +1,19 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import React, { useState } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { doc, getDoc } from 'firebase/firestore';
+import React, { useEffect, useState } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { ScreenContainer } from '@/components/ui/ScreenContainer';
 import { TextField } from '@/components/ui/TextField';
 import { AppColors, Spacing, Typography } from '@/constants/theme';
+import { db } from '@/api/firebase';
+import { COLLECTIONS } from '@/constants/firestore';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import { useRewardClaim } from '@/features/rewards/hooks/useRewardClaim';
 import { useGameState } from '@/providers/GameStateProvider';
+import { type Sponsor } from '@/types';
 
 export function RewardClaimScreen() {
   const router = useRouter();
@@ -22,6 +26,49 @@ export function RewardClaimScreen() {
   const [email, setEmail] = useState(user?.email ?? '');
   const [phone, setPhone] = useState('');
   const [emailError, setEmailError] = useState('');
+  const [sponsors, setSponsors] = useState<Sponsor[]>([]);
+  const [selectedSponsorId, setSelectedSponsorId] = useState<string | null>(
+    null,
+  );
+  const [sponsorError, setSponsorError] = useState('');
+  const [isLoadingSponsors, setIsLoadingSponsors] = useState(true);
+
+  useEffect(() => {
+    const sponsorIds =
+      session?.sponsorIds && session.sponsorIds.length > 0
+        ? session.sponsorIds
+        : session?.sponsorId
+          ? [session.sponsorId]
+          : [];
+
+    if (sponsorIds.length === 0) {
+      setSponsors([]);
+      setSelectedSponsorId(null);
+      setIsLoadingSponsors(false);
+      return;
+    }
+
+    setIsLoadingSponsors(true);
+    Promise.all(
+      sponsorIds.map(async (sponsorId) => {
+        const snap = await getDoc(doc(db, COLLECTIONS.SPONSORS, sponsorId));
+        if (!snap.exists()) return null;
+        return { id: snap.id, ...(snap.data() as Omit<Sponsor, 'id'>) };
+      }),
+    )
+      .then((loadedSponsors) => {
+        const nextSponsors = loadedSponsors.filter(
+          (s): s is Sponsor => s !== null,
+        );
+        setSponsors(nextSponsors);
+        setSelectedSponsorId((prev) =>
+          prev && nextSponsors.some((sponsor) => sponsor.id === prev)
+            ? prev
+            : nextSponsors[0]?.id ?? null,
+        );
+      })
+      .finally(() => setIsLoadingSponsors(false));
+  }, [session?.sponsorId, session?.sponsorIds]);
 
   function validateEmail(value: string): boolean {
     const trimmed = value.trim();
@@ -39,12 +86,17 @@ export function RewardClaimScreen() {
 
   async function handleSubmit() {
     if (!validateEmail(email)) return;
-    if (!user?.uid || !session?.sponsorId) return;
+    if (!selectedSponsorId) {
+      setSponsorError('Please select a reward first.');
+      return;
+    }
+    if (!user?.uid) return;
 
+    setSponsorError('');
     await submit(
       user.uid,
       sessionId,
-      session.sponsorId,
+      selectedSponsorId,
       email,
       phone.trim() || null,
     );
@@ -83,10 +135,50 @@ export function RewardClaimScreen() {
 
       <Text style={styles.title}>Claim Your Reward</Text>
       <Text style={styles.subtitle}>
-        Confirm your contact details so the sponsor can reach you.
+        Choose your reward, then confirm your contact details.
       </Text>
 
       <Card style={styles.formCard}>
+        <Text style={styles.sectionLabel}>Choose a Sponsor Reward</Text>
+        {isLoadingSponsors ? (
+          <ActivityIndicator color={AppColors.accent} style={styles.spinner} />
+        ) : sponsors.length === 0 ? (
+          <Text style={styles.emptySponsors}>
+            No sponsor rewards are configured for this session.
+          </Text>
+        ) : (
+          sponsors.map((sponsor) => {
+            const selected = selectedSponsorId === sponsor.id;
+            return (
+              <Pressable
+                key={sponsor.id}
+                onPress={() => {
+                  setSelectedSponsorId(sponsor.id);
+                  if (sponsorError) setSponsorError('');
+                }}
+                style={({ pressed }) => [pressed && styles.pressed]}
+                accessibilityRole="radio"
+                accessibilityState={{ checked: selected }}
+              >
+                <Card
+                  style={[
+                    styles.sponsorOptionCard,
+                    selected ? styles.sponsorOptionSelected : null,
+                  ]}
+                >
+                  <Text style={styles.sponsorName}>{sponsor.name}</Text>
+                  {!!sponsor.rewardDescription && (
+                    <Text style={styles.sponsorRewardText}>
+                      {sponsor.rewardDescription}
+                    </Text>
+                  )}
+                </Card>
+              </Pressable>
+            );
+          })
+        )}
+        {sponsorError ? <Text style={styles.errorText}>{sponsorError}</Text> : null}
+
         <TextField
           label="Email Address"
           value={email}
@@ -147,6 +239,43 @@ const styles = StyleSheet.create({
   formCard: {
     backgroundColor: AppColors.bgElevated,
     gap: Spacing.base,
+  },
+  sectionLabel: {
+    ...Typography.label,
+    color: AppColors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  spinner: {
+    marginVertical: Spacing.xs,
+  },
+  emptySponsors: {
+    ...Typography.bodySmall,
+    color: AppColors.textMuted,
+    fontStyle: 'italic',
+  },
+  sponsorOptionCard: {
+    backgroundColor: AppColors.bgPrimary,
+    borderColor: AppColors.borderSubtle,
+    marginBottom: Spacing.xs,
+    gap: Spacing.xs,
+  },
+  sponsorOptionSelected: {
+    borderColor: AppColors.accent,
+    borderWidth: 2,
+    backgroundColor: AppColors.accentSoft,
+  },
+  pressed: {
+    opacity: 0.8,
+  },
+  sponsorName: {
+    ...Typography.body,
+    color: AppColors.textPrimary,
+    fontWeight: '600',
+  },
+  sponsorRewardText: {
+    ...Typography.bodySmall,
+    color: AppColors.textSecondary,
   },
   privacyNote: {
     ...Typography.bodySmall,

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -30,6 +30,7 @@ export interface AuthContextValue {
     teamId: string | null,
   ) => Promise<void>;
   signOut: () => Promise<void>;
+  setUserTeam: (teamId: string | null) => void;
 }
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
@@ -89,9 +90,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setFirebaseUser(null);
   }, []);
 
+  const setUserTeam = useCallback((teamId: string | null) => {
+    setUser((prev) => (prev ? { ...prev, teamId } : prev));
+  }, []);
+
   const value = useMemo<AuthContextValue>(
-    () => ({ user, firebaseUser, isLoading, signIn, signUp, signOut }),
-    [user, firebaseUser, isLoading, signIn, signUp, signOut],
+    () => ({
+      user,
+      firebaseUser,
+      isLoading,
+      signIn,
+      signUp,
+      signOut,
+      setUserTeam,
+    }),
+    [user, firebaseUser, isLoading, signIn, signUp, signOut, setUserTeam],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -31,6 +31,7 @@ export interface AuthContextValue {
   ) => Promise<void>;
   signOut: () => Promise<void>;
   setUserTeam: (teamId: string | null) => void;
+  setUserMarketingOptIn: (marketingOptIn: boolean) => void;
 }
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
@@ -94,6 +95,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setUser((prev) => (prev ? { ...prev, teamId } : prev));
   }, []);
 
+  const setUserMarketingOptIn = useCallback((marketingOptIn: boolean) => {
+    setUser((prev) => (prev ? { ...prev, marketingOptIn } : prev));
+  }, []);
+
   const value = useMemo<AuthContextValue>(
     () => ({
       user,
@@ -103,8 +108,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       signUp,
       signOut,
       setUserTeam,
+      setUserMarketingOptIn,
     }),
-    [user, firebaseUser, isLoading, signIn, signUp, signOut, setUserTeam],
+    [
+      user,
+      firebaseUser,
+      isLoading,
+      signIn,
+      signUp,
+      signOut,
+      setUserTeam,
+      setUserMarketingOptIn,
+    ],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -6,6 +6,7 @@ export type GameStatus = 'lobby' | 'active' | 'completed';
 
 export interface GameSession {
   id: string;
+  title?: string;
   status: GameStatus;
   currentQuestionId: string | null;
   questionActive: boolean;

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -10,7 +10,8 @@ export interface GameSession {
   currentQuestionId: string | null;
   questionActive: boolean;
   questionStartTime: Timestamp | null;
-  sponsorId: string;
+  sponsorIds: string[];
+  sponsorId?: string;
   settings: {
     showTeamScores: boolean;
     allowLateJoin: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,5 +3,6 @@ export * from './question';
 export * from './reward';
 export * from './sponsor';
 export * from './submission';
+export * from './sessionParticipant';
 export * from './team';
 export * from './user';

--- a/src/types/sessionParticipant.ts
+++ b/src/types/sessionParticipant.ts
@@ -1,0 +1,10 @@
+import { Timestamp } from 'firebase/firestore';
+
+export interface SessionParticipant {
+  id: string;
+  sessionId: string;
+  uid: string;
+  teamId: string;
+  joinedAt: Timestamp;
+  updatedAt?: Timestamp;
+}


### PR DESCRIPTION
## Summary
- Add a fan settings screen where users can update `marketingOptIn` after signup.
- Add per-session team membership support via a new `session_participants` store.
- Enforce strict team-change guardrail: fans can only change team before their first submission in that session.
- Update answer submission to resolve team from session participant data (with safe fallback/init behavior).
- Add a role-gate routing fix so profile updates (like opt-in toggles) do not force unwanted navigation away from fan subroutes.
## Why
Fans need to manage marketing preference after account creation and correct accidental team picks. Team switching also needs fairness protection, so it must lock once a fan has submitted an answer in that session.
## Implementation details
- New collection constant: `SESSION_PARTICIPANTS`.
- New service: `sessionParticipantService` with:
  - `getSessionParticipant`
  - `canChangeSessionTeam`
  - `upsertSessionTeamStrict`
  - `resolveSessionTeamForAnswer`
- Team selection now:
  - preloads current session team when available,
  - blocks changes once locked,
  - shows locked state in the CTA.
- Lobby includes `Change Team` action.
- Game selection includes `Settings` action.
- New fan route: `/(fan)/settings`.
## Test Plan
- [ ] Open fan settings and toggle marketing opt-in on/off.
- [ ] Confirm toggle persists after navigating away and returning.
- [ ] Confirm settings page stays open after toggle (no auto-redirect).
- [ ] Join a session with no prior answers, change team, save successfully.
- [ ] Submit first answer in the session, return to team selection, verify team change is locked.
- [ ] Verify submitting answers uses the session-resolved team.
- [ ] Verify existing fan/admin role routing still behaves correctly on login and refresh.
## Notes
- This introduces a session-scoped team source of truth while still keeping user-level team updates for compatibility.

closes #35 